### PR TITLE
Add image analysis API route with valid syntax

### DIFF
--- a/app/api/analyze-image/route.js
+++ b/app/api/analyze-image/route.js
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req) {
+  try {
+    const payload = await req.json();
+    const finalResponse = {
+      analysis: formatAnalysisResult(payload, 'demo')
+    };
+    return NextResponse.json(finalResponse);
+  } catch (error) {
+    console.error('=== IMAGE ANALYSIS ERROR ===');
+    console.error('Error:', error);
+    console.error('Error stack:', error.stack);
+    return NextResponse.json({ error: 'Image analysis failed' }, { status: 500 });
+  }
+}
+
+function formatAnalysisResult(raw, type) {
+  return { type, raw };
+}


### PR DESCRIPTION
## Summary
- add `app/api/analyze-image/route.js` with basic image analysis handler and formatting helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many react/no-unescaped-entities warnings in existing files)*
- `npx eslint app/api/analyze-image/route.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6d483c98483339fe3b744667b2069